### PR TITLE
Allow ignoring files

### DIFF
--- a/core/src/main/scala/net/runne/sitelinkvalidator/Main.scala
+++ b/core/src/main/scala/net/runne/sitelinkvalidator/Main.scala
@@ -61,7 +61,11 @@ class Validator(appConfig: Config) {
     val linkMappings = mappings.map { c =>
       c.getString("prefix") -> c.getString("replace")
     }.toMap
-    HtmlFileReader.Config(rootDir, linkMappings, config.getStringList("ignore-prefixes").asScala.toList)
+    HtmlFileReader.Config(
+      rootDir,
+      linkMappings,
+      config.getStringList("ignore-files").asScala.toList,
+      config.getStringList("ignore-prefixes").asScala.toList)
   }
 
   val nonHttpsAccepted =


### PR DESCRIPTION
Adds an `ignore-files` option that accepts a list of local files that should not be checked for invalid external links. Internal links are still followed.