### PR TITLE
fix: link collector error handling

### DIFF
--- a/core/src/main/scala/net/runne/sitelinkvalidator/LinkCollector.scala
+++ b/core/src/main/scala/net/runne/sitelinkvalidator/LinkCollector.scala
@@ -1,60 +1,37 @@
 package net.runne.sitelinkvalidator
 
 import java.nio.file.{ Path, Paths }
+import akka.actor.typed.ActorRef
 
-import akka.NotUsed
-import akka.actor.typed.{ ActorRef, ActorSystem }
-import akka.stream.OverflowStrategy
-import akka.stream.scaladsl.{ Flow, Sink }
-import akka.stream.typed.scaladsl.ActorSource
-
-import scala.concurrent.Promise
-import scala.concurrent.duration._
+import scala.annotation.tailrec
 
 object LinkCollector {
 
   final case class FileLocation(origin: Path, file: Path)
 
+  // Find all links and pass them to `anchorCollector` and `urlTester`
   def stream(
+      root: FileLocation,
       htmlFileReaderConfig: HtmlFileReader.Config,
       reporter: ActorRef[Reporter.Messages],
       anchorCollector: ActorRef[AnchorValidator.Messages],
-      urlTester: ActorRef[UrlTester.Messages])(implicit system: ActorSystem[_]): ActorRef[FileLocation] = {
-    implicit val ec = system.executionContext
+      urlTester: ActorRef[UrlTester.Messages]): Unit = {
 
-    def unique[T]: Flow[T, T, NotUsed] = Flow[T].statefulMapConcat { () =>
-      var seen: Set[T] = Set.empty
-      value =>
-        if (seen.contains(value)) List()
-        else {
-          seen = seen + value
-          List(value)
-        }
+    @tailrec
+    def recurse(todo: List[FileLocation], done: Set[Path]): Unit = {
+      todo match {
+        case Nil =>
+        case fileLocation :: xs =>
+          val html = findHtml(fileLocation.file.normalize)
+          if (done(html) || !html.toFile.isFile) {
+            recurse(xs, done)
+          } else {
+            val links = HtmlFileReader.findLinks(htmlFileReaderConfig, reporter, anchorCollector, urlTester, html)
+            recurse(xs ++ links, done + html)
+          }
+      }
     }
-
-    val self = Promise[ActorRef[FileLocation]]()
-    val collector = ActorSource
-      .actorRef[FileLocation](
-        completionMatcher = PartialFunction.empty,
-        failureMatcher = PartialFunction.empty,
-        5000,
-        OverflowStrategy.fail)
-      // termination of this stream signals end of processing
-      .idleTimeout(500.millis)
-      .map { case FileLocation(_, file) =>
-        findHtml(file.normalize)
-      }
-      .via(unique)
-      .filter(_.toFile.isFile)
-      .mapAsync(100) { file =>
-        self.future.map { linkCollector =>
-          HtmlFileReader.findLinks(htmlFileReaderConfig, reporter, anchorCollector, urlTester, linkCollector, file)
-        }
-      }
-      .to(Sink.ignore)
-      .run()
-    self.success(collector)
-    collector
+    recurse(List(root), Set.empty)
   }
 
   private def findHtml(p: Path) = {


### PR DESCRIPTION
I noticed in `LinkCollector` there didn't appear to be error handling for the case that the `ActorSource.actorRef` would fail (when hitting the 5000 buffer size), plus the termination condition of `.idleTimeout(500.millis)` seemed like a workaround.

I tried to, instead of using a stream here, use regular recursion. This perhaps reduces the parallelism in reading the site from disk, but the bottleneck is likely in the network calls anyway, and those are still in parallel to reading from disk.